### PR TITLE
Add a Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: php
+
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
+php:
+    - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
+    - hhvm
+
+matrix:
+    include:
+        - php: 5.4
+          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
+        - php: 5.6
+          env: DEPENDENCIES=dev
+
+before_install:
+    - composer self-update
+    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+
+install:
+    - composer update $COMPOSER_FLAGS
+
+script:
+    - bin/phpspec -f dot
+    - phpunit -v


### PR DESCRIPTION
This adds a configuration file for Travis. This allows to have a CI server running for any commit and PR

It would be great to enable Travis on the repo (only for builds containing a config file to avoid running other ones as Ruby). I can then trigger a new build for this PR to make it run.