### PR TITLE
OptionsResolver::setOptional is deprecated since Symfony 2.6

### DIFF
--- a/src/Csv/RowIterator.php
+++ b/src/Csv/RowIterator.php
@@ -127,7 +127,7 @@ class RowIterator implements \Iterator
      */
     protected function setDefaultOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(['encoding']);
+        $resolver->setDefined(['encoding']);
         $resolver->setDefaults(
             [
                 'length'    => null,


### PR DESCRIPTION
Fix #17 