### PR TITLE
OptionsResolver::setOptional is deprecated since Symfony 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/options-resolver": "2.*"
+        "symfony/options-resolver": "~2.6.0"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.*@dev"

--- a/src/Csv/RowIterator.php
+++ b/src/Csv/RowIterator.php
@@ -127,7 +127,7 @@ class RowIterator implements \Iterator
      */
     protected function setDefaultOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(['encoding']);
+        $resolver->setDefined(['encoding']);
         $resolver->setDefaults(
             [
                 'length'    => null,


### PR DESCRIPTION
Fix #17 