### PR TITLE
Use maintained versions of the symfony component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/options-resolver": "~2.6.0"
+        "symfony/options-resolver": "~2.6 || ~3.0"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.*@dev"


### PR DESCRIPTION
The previous constraint only allowed ``2.6.*`` releases, which are not maintained anymore