### PR TITLE
Keep reference to the Archive in objects relying on an extracted path

### DIFF
--- a/spec/Akeneo/Component/SpreadsheetParser/Xlsx/RowIteratorFactorySpec.php
+++ b/spec/Akeneo/Component/SpreadsheetParser/Xlsx/RowIteratorFactorySpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Component\SpreadsheetParser\Xlsx;
 
+use Akeneo\Component\SpreadsheetParser\Xlsx\Archive;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Component\SpreadsheetParser\Xlsx\ColumnIndexTransformer;
 use Akeneo\Component\SpreadsheetParser\Xlsx\RowBuilderFactory;
@@ -26,9 +27,10 @@ class RowIteratorFactorySpec extends ObjectBehavior
     public function it_creates_row_iterators(
         RowBuilderFactory $rowBuilderFactory,
         ColumnIndexTransformer $columnIndexTransformer,
-        ValueTransformer $valueTransformer
+        ValueTransformer $valueTransformer,
+        Archive $archive
     ) {
-        $iterator = $this->create($valueTransformer, 'path', ['options']);
+        $iterator = $this->create($valueTransformer, 'path', ['options'], $archive);
         $iterator->getPath()->shouldReturn('path');
         $iterator->getOptions()->shouldReturn(['options']);
         $iterator->getValueTransformer()->shouldReturn($valueTransformer);

--- a/spec/Akeneo/Component/SpreadsheetParser/Xlsx/RowIteratorSpec.php
+++ b/spec/Akeneo/Component/SpreadsheetParser/Xlsx/RowIteratorSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Akeneo\Component\SpreadsheetParser\Xlsx;
 
 use PhpSpec\ObjectBehavior;
+use Akeneo\Component\SpreadsheetParser\Xlsx\Archive;
 use Akeneo\Component\SpreadsheetParser\Xlsx\ColumnIndexTransformer;
 use Akeneo\Component\SpreadsheetParser\Xlsx\RowBuilder;
 use Akeneo\Component\SpreadsheetParser\Xlsx\RowBuilderFactory;
@@ -15,7 +16,8 @@ class RowIteratorSpec extends ObjectBehavior
         RowBuilderFactory $rowBuilderFactory,
         ColumnIndexTransformer $columnIndexTransformer,
         ValueTransformer $valueTransformer,
-        RowBuilder $rowBuilder
+        RowBuilder $rowBuilder,
+        Archive $archive
     )
     {
         $startWith = function ($startString) {
@@ -52,7 +54,8 @@ class RowIteratorSpec extends ObjectBehavior
             $columnIndexTransformer,
             $valueTransformer,
             __DIR__ . '/fixtures/sheet.xml',
-            []
+            [],
+            $archive
         );
         $valueTransformer->transform(Argument::type('string'), Argument::type('string'), Argument::type('string'))
             ->will(

--- a/spec/Akeneo/Component/SpreadsheetParser/Xlsx/SharedStringsLoaderSpec.php
+++ b/spec/Akeneo/Component/SpreadsheetParser/Xlsx/SharedStringsLoaderSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Component\SpreadsheetParser\Xlsx;
 
+use Akeneo\Component\SpreadsheetParser\Xlsx\Archive;
 use PhpSpec\ObjectBehavior;
 
 class SharedStringsLoaderSpec extends ObjectBehavior
@@ -16,23 +17,32 @@ class SharedStringsLoaderSpec extends ObjectBehavior
         $this->shouldHaveType('Akeneo\Component\SpreadsheetParser\Xlsx\SharedStringsLoader');
     }
 
-    public function it_loads_shared_strings()
+    public function it_loads_shared_strings(Archive $archive)
     {
-        $this->open('path')->getPath()->shouldReturn('path');
+        $sharedStrings = $this->open('path', $archive);
+        $sharedStrings->getPath()->shouldReturn('path');
+        $sharedStrings->getArchive()->shouldReturn($archive);
     }
 }
 
 class StubSharedStrings
 {
     protected $path;
+    private $archive;
 
-    public function __construct($path)
+    public function __construct($path, Archive $archive)
     {
         $this->path = $path;
+        $this->archive = $archive;
     }
 
     public function getPath()
     {
         return $this->path;
+    }
+
+    public function getArchive()
+    {
+        return $this->archive;
     }
 }

--- a/spec/Akeneo/Component/SpreadsheetParser/Xlsx/SpreadsheetSpec.php
+++ b/spec/Akeneo/Component/SpreadsheetParser/Xlsx/SpreadsheetSpec.php
@@ -65,11 +65,11 @@ class SpreadsheetSpec extends ObjectBehavior
         $relationships->getSharedStringsPath()->willReturn('shared_strings');
         $relationships->getStylesPath()->willReturn('styles');
 
-        $sharedStringsLoader->open('temp_shared_strings')
+        $sharedStringsLoader->open('temp_shared_strings', $archive)
             ->should($beCalledAtMostOnce)
             ->willReturn($sharedStrings);
 
-        $stylesLoader->open(('temp_styles'))->willReturn($styles);
+        $stylesLoader->open(('temp_styles'), $archive)->willReturn($styles);
         $valueTransformerFactory->create($sharedStrings, $styles)->willReturn($valueTransformer);
 
         $worksheetListReader->getWorksheetPaths($relationships, 'temp_' . Spreadsheet::WORKBOOK_PATH)
@@ -91,10 +91,11 @@ class SpreadsheetSpec extends ObjectBehavior
         ValueTransformer $valueTransformer,
         RowIteratorFactory $rowIteratorFactory,
         RowIterator $rowIterator1,
-        RowIterator $rowIterator2
+        RowIterator $rowIterator2,
+        Archive $archive
     ) {
-        $rowIteratorFactory->create($valueTransformer, 'temp_path1', [])->willReturn($rowIterator1);
-        $rowIteratorFactory->create($valueTransformer, 'temp_path2', [])->willReturn($rowIterator2);
+        $rowIteratorFactory->create($valueTransformer, 'temp_path1', [], $archive)->willReturn($rowIterator1);
+        $rowIteratorFactory->create($valueTransformer, 'temp_path2', [], $archive)->willReturn($rowIterator2);
 
         $this->createRowIterator(0)->shouldReturn($rowIterator1);
         $this->createRowIterator(1)->shouldReturn($rowIterator2);

--- a/spec/Akeneo/Component/SpreadsheetParser/Xlsx/StylesLoaderSpec.php
+++ b/spec/Akeneo/Component/SpreadsheetParser/Xlsx/StylesLoaderSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Component\SpreadsheetParser\Xlsx;
 
+use Akeneo\Component\SpreadsheetParser\Xlsx\Archive;
 use PhpSpec\ObjectBehavior;
 
 class StylesLoaderSpec extends ObjectBehavior
@@ -16,23 +17,32 @@ class StylesLoaderSpec extends ObjectBehavior
         $this->shouldHaveType('Akeneo\Component\SpreadsheetParser\Xlsx\StylesLoader');
     }
 
-    public function it_loads_shared_strings()
+    public function it_loads_styles(Archive $archive)
     {
-        $this->open('path')->getPath()->shouldReturn('path');
+        $styles = $this->open('path', $archive);
+        $styles->getPath()->shouldReturn('path');
+        $styles->getArchive()->shouldReturn($archive);
     }
 }
 
 class StubStyles
 {
     protected $path;
+    private $archive;
 
-    public function __construct($path)
+    public function __construct($path, Archive $archive)
     {
         $this->path = $path;
+        $this->archive = $archive;
     }
 
     public function getPath()
     {
         return $this->path;
+    }
+
+    public function getArchive()
+    {
+        return $this->archive;
     }
 }

--- a/src/Xlsx/AbstractXMLResource.php
+++ b/src/Xlsx/AbstractXMLResource.php
@@ -22,13 +22,25 @@ abstract class AbstractXMLResource
     private $xml;
 
     /**
+     * The Archive from which the path was extracted.
+     *
+     * A reference to the object is kept here to ensure that it is not deleted
+     * before the RowIterator, as this would remove the extraction folder.
+     *
+     * @var Archive
+     */
+    private $archive;
+
+    /**
      * Constructor
      *
-     * @param string $path path to the extracted shared strings XML file
+     * @param string        $path    path to the extracted shared strings XML file
+     * @param Archive|null  $archive The Archive from which the path was extracted
      */
-    public function __construct($path)
+    public function __construct($path, Archive $archive = null)
     {
         $this->path = $path;
+        $this->archive = $archive;
     }
 
     /**
@@ -76,5 +88,4 @@ abstract class AbstractXMLResource
         $this->xml->close();
         $this->xml = null;
     }
-
 }

--- a/src/Xlsx/RowIterator.php
+++ b/src/Xlsx/RowIterator.php
@@ -7,7 +7,7 @@ namespace Akeneo\Component\SpreadsheetParser\Xlsx;
  *
  * The iterator returns arrays of results.
  *
- * Empty values are trimed from the right of the rows, and empty rows are skipped.
+ * Empty values are trimmed from the right of the rows, and empty rows are skipped.
  *
  * @author    Antoine Guigan <antoine@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
@@ -61,6 +61,16 @@ class RowIterator implements \Iterator
     protected $valid;
 
     /**
+     * The Archive from which the path was extracted.
+     *
+     * A reference to the object is kept here to ensure that it is not deleted
+     * before the RowIterator, as this would remove the extraction folder.
+     *
+     * @var Archive
+     */
+    private $archive;
+
+    /**
      * Constructor
      *
      * @param RowBuilderFactory      $rowBuilderFactory
@@ -68,19 +78,22 @@ class RowIterator implements \Iterator
      * @param ValueTransformer       $valueTransformer
      * @param string                 $path
      * @param array                  $options
+     * @param Archive                $archive                The Archive from which the path was extracted
      */
     public function __construct(
         RowBuilderFactory $rowBuilderFactory,
         ColumnIndexTransformer $columnIndexTransformer,
         ValueTransformer $valueTransformer,
         $path,
-        array $options
+        array $options,
+        Archive $archive
     ) {
         $this->rowBuilderFactory = $rowBuilderFactory;
         $this->columnIndexTransformer = $columnIndexTransformer;
         $this->valueTransformer = $valueTransformer;
         $this->path = $path;
         $this->options = $options;
+        $this->archive = $archive;
     }
 
     /**

--- a/src/Xlsx/RowIteratorFactory.php
+++ b/src/Xlsx/RowIteratorFactory.php
@@ -53,17 +53,19 @@ class RowIteratorFactory
      * @param ValueTransformer $valueTransformer the value transformer for the spreadsheet
      * @param string           $path             the path to the extracted XML worksheet file
      * @param array            $options          options specific to the format
+     * @param Archive          $archive          The Archive from which the path was extracted
      *
      * @return RowIterator
      */
-    public function create(ValueTransformer $valueTransformer, $path, array $options)
+    public function create(ValueTransformer $valueTransformer, $path, array $options, Archive $archive)
     {
         return new $this->iteratorClass(
             $this->rowBuilderFactory,
             $this->columnIndexTransformer,
             $valueTransformer,
             $path,
-            $options
+            $options,
+            $archive
         );
     }
 

--- a/src/Xlsx/SharedStringsLoader.php
+++ b/src/Xlsx/SharedStringsLoader.php
@@ -31,13 +31,14 @@ class SharedStringsLoader
     /**
      * Creates a SharedStrings from the archive
      *
-     * @param string $path
+     * @param string  $path
+     * @param Archive $archive The Archive from which the path was extracted
      *
      * @return SharedStrings
      */
-    public function open($path)
+    public function open($path, Archive $archive)
     {
-        return new $this->sharedStringsClass($path);
+        return new $this->sharedStringsClass($path, $archive);
     }
 
 }

--- a/src/Xlsx/Spreadsheet.php
+++ b/src/Xlsx/Spreadsheet.php
@@ -133,7 +133,8 @@ class Spreadsheet implements SpreadsheetInterface
         return $this->rowIteratorFactory->create(
             $this->getValueTransformer(),
             $this->archive->extract($paths[$worksheetIndex]),
-            $options
+            $options,
+            $this->archive
         );
     }
 
@@ -180,7 +181,7 @@ class Spreadsheet implements SpreadsheetInterface
     {
         if (!$this->sharedStrings) {
             $path = $this->archive->extract($this->relationships->getSharedStringsPath());
-            $this->sharedStrings = $this->sharedStringsLoader->open($path);
+            $this->sharedStrings = $this->sharedStringsLoader->open($path, $this->archive);
         }
 
         return $this->sharedStrings;
@@ -206,7 +207,7 @@ class Spreadsheet implements SpreadsheetInterface
     {
         if (!$this->styles) {
             $path = $this->archive->extract($this->relationships->getStylesPath());
-            $this->styles = $this->stylesLoader->open($path);
+            $this->styles = $this->stylesLoader->open($path, $this->archive);
         }
 
         return $this->styles;

--- a/src/Xlsx/StylesLoader.php
+++ b/src/Xlsx/StylesLoader.php
@@ -29,12 +29,13 @@ class StylesLoader
     /**
      * Creates a Styles from the archive
      *
-     * @param string $path
+     * @param string  $path
+     * @param Archive $archive The Archive from which the path was extracted
      *
      * @return Styles
      */
-    public function open($path)
+    public function open($path, Archive $archive)
     {
-        return new $this->class($path);
+        return new $this->class($path, $archive);
     }
 }


### PR DESCRIPTION
The Archive deletes its extraction folder in its destructor. This means that references to the Archive object must be kept until all objects using extracted files are gone.
This fixes 2 issues:

- a RowIterator can now outlive the Spreadsheet object (previously, the archive got deleted, leaving the iterator unusable as it would reference a missing file), which allows to return it from a function. This closes #34
- Previously, destructing a Spreadsheet object could trigger warnings and leak extracted files in case the Archive was destructed before the SharedStrings or Styles objects, as these objects would still hold an  opened file descriptor inside the temporary folder and so preventing removal. The reference to the Archive in these objects ensures that the Archive instance will be deleted only after them. Closes #12