### PR TITLE
Handle values of type InlineString

### DIFF
--- a/src/Xlsx/RowIterator.php
+++ b/src/Xlsx/RowIterator.php
@@ -146,6 +146,14 @@ class RowIterator implements \Iterator
                     case 'is':
                         $rowBuilder->addValue($columnIndex, $this->xml->readString());
                         break;
+                    case 't':
+                        if($type == ValueTransformer::TYPE_INLINE_STRING) {
+                            $rowBuilder->addValue(
+                                $columnIndex,
+                                $this->valueTransformer->transform($this->xml->readString(), $type, $style)
+                                );
+                        }
+                        break;
                 }
             } elseif (\XMLReader::END_ELEMENT === $this->xml->nodeType) {
                 switch ($this->xml->name) {


### PR DESCRIPTION
Noticed that inlineString where not being parsed if there are no sharedString available.

This adds handling for values of type 'inlineString' when there are no shareStrings available.