### PR TITLE
Add the option to allow the iteration of empty rows for xlsx files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 phpunit.xml
 ~$*.xlsx
 /nbproject
+/.idea

--- a/src/Xlsx/RowBuilder.php
+++ b/src/Xlsx/RowBuilder.php
@@ -23,10 +23,11 @@ class RowBuilder
      *
      * @param int    $columnIndex
      * @param string $value
+     * @param bool   $allowEmptyValues
      */
-    public function addValue($columnIndex, $value)
+    public function addValue($columnIndex, $value, $allowEmptyValues = false)
     {
-        if ('' !== $value) {
+        if ('' !== $value || $allowEmptyValues) {
             $this->values[$columnIndex] = $value;
         }
     }


### PR DESCRIPTION
This is especially useful when trying to count the real number of rows of a file, including the empty ones.